### PR TITLE
feat: change input to accept express `request` and `response`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # bunyan-express-common-log-format
 
-Bunyan Common Log Format serializer for ExpressJS applications.
+[Bunyan](https://github.com/trentm/node-bunyan)
+[Common Log Format](https://en.wikipedia.org/wiki/Common_Log_Format) serializer for
+[ExpressJS](https://expressjs.com/) applications.
 
 ## Setup
 
@@ -21,7 +23,7 @@ const bunyan = require('bunyan');
 const bunyanExpressCommonLogFormat = require('bunyan-express-common-log-format');
 
 const logger = bunyan.createLogger({
-  serializers: { response: bunyanExpressCommonLogFormat },
+  serializers: { apiCall: bunyanExpressCommonLogFormat },
   // other bunyan configuration here
 });
 
@@ -31,7 +33,9 @@ module.exports = logger;
 ## Usage
 
 Once the formatter is installed and the serializer is set-up, use it with a normal log call, using
-the key used during bunyan setup:
+the key used during bunyan setup (`apiCall` in the example):
+
+### Basic usage
 
 ```js
 const express = require('express');
@@ -45,19 +49,60 @@ app.get(/* ... */);
 
 // define the logging middleware
 app.use((request, response, next) => {
+  logger.info({ apiCall: { request, response } }, 'Express API Call');
+  next();
+});
+```
+
+### Overrides
+
+The serializer will do it's best to extract the necessary information from the given `request` and
+`response` objects, except for `authUser` and `ident`, which are currently not extracted. All fields
+can be overridden with custom values. Pass an `overrides` object to override any field. The
+available fields are:
+
+| Field           | Type   | Description                                                                |
+| --------------- | ------ | -------------------------------------------------------------------------- |
+| `authUser`      | string | The `userid` of the person requesting the resource                         |
+| `contentLength` | string | The size of the object returned to the client, in _bytes_                  |
+| `date`          | date   | The _date_, _time_ and _timezone_ of the response                          |
+| `host`          | string | The host that requested the resource                                       |
+| `httpVersion`   | string | The HTTP Protocol used                                                     |
+| `ident`         | string | The [https://tools.ietf.org/html/rfc1413](RFC 1413) identity of the client |
+| `method`        | string | The request method used to request the resource                            |
+| `statusCode`    | string | The HTTP status code returned to the client                                |
+| `url`           | string | The URL requested by the client                                            |
+
+This is implemented as follows:
+
+```js
+// define the logging middleware
+app.use((request, response, next) => {
   logger.info(
-    {
-      response: {
-        contentLength: response.get('Content-Length'),
-        date: new Date(),
-        host: request.headers.host,
-        httpVersion: request.httpVersion,
-        method: request.method,
-        statusCode: response.statusCode,
-        url: request.originalUrl,
-      },
-    },
+    { apiCall: { overrides: { authUser: 'hvolschenk' }, request, response } },
+    'Express API Call',
   );
   next();
-};);
+});
+```
+
+### Settings
+
+Pass a `settings` object to change settings of the serializer. The available settings are:
+
+| Name         | Type   | Description |
+| ------------ | ------ | ----------- |
+| `dateFormat` | string | The date format to use, please see the [dateformat](https://www.npmjs.com/package/dateformat) package for options |
+
+This is implemented as follows:
+
+```js
+// define the logging middleware
+app.use((request, response, next) => {
+  logger.info(
+    { apiCall: { request, response, settings: { dateFormat: 'mmmm dS, yyyy, h:MM:ss TT' } } },
+    'Express API Call',
+  );
+  next();
+});
 ```

--- a/src/format-date.js
+++ b/src/format-date.js
@@ -1,0 +1,3 @@
+const dateformat = require('dateformat');
+
+module.exports = (date, format = 'dd/mmm/yyyy:hh:MM:ss o') => dateformat(date, format);

--- a/src/format-date.test.js
+++ b/src/format-date.test.js
@@ -1,0 +1,37 @@
+test('Formats a date with the default format', () => {
+  const DATE = 'DATE';
+  const mockDateFormat = jest.fn();
+  jest.doMock('dateformat', () => mockDateFormat);
+  const expectedOne = DATE;
+  const expectedTwo = 'dd/mmm/yyyy:hh:MM:ss o';
+
+  // eslint-disable-next-line global-require
+  const formatDate = require('./format-date');
+  formatDate(DATE);
+  const dateformatCall = mockDateFormat.mock.calls[0];
+  const actualOne = dateformatCall[0];
+  const actualTwo = dateformatCall[1];
+
+  expect(actualOne).toBe(expectedOne);
+  expect(actualTwo).toBe(expectedTwo);
+});
+
+test('Formats a date with a custom format', () => {
+  const DATE = 'DATE';
+  const DATE_FORMAT = 'DATE_FORMAT';
+  const mockDateFormat = jest.fn();
+  jest.doMock('dateformat', () => mockDateFormat);
+  const expectedOne = DATE;
+  const expectedTwo = DATE_FORMAT;
+
+  jest.resetModules();
+  // eslint-disable-next-line global-require
+  const formatDate = require('./format-date');
+  formatDate(DATE, DATE_FORMAT);
+  const dateformatCall = mockDateFormat.mock.calls[0];
+  const actualOne = dateformatCall[0];
+  const actualTwo = dateformatCall[1];
+
+  expect(actualOne).toBe(expectedOne);
+  expect(actualTwo).toBe(expectedTwo);
+});

--- a/src/index.js
+++ b/src/index.js
@@ -1,16 +1,19 @@
-const dateFormat = require('dateformat');
+const formatDate = require('./format-date');
+const parseExpressOptions = require('./parse-express-options');
 
-const formatDate = date => dateFormat(date, 'dd/mmm/yyyy:hh:MM:ss o');
-
-module.exports = ({
-  authUser = '-',
-  contentLength = '-',
-  date = '-',
-  host = '-',
-  httpVersion,
-  ident = '-',
-  method,
-  statusCode = '-',
-  url,
-}) => `${host} ${ident} ${authUser} [${date === '-' ? '-' : formatDate(date)}] "${method} ${url} `
-  + `HTTP/${httpVersion}" ${statusCode} ${contentLength}`;
+module.exports = ({ overrides, request, response, settings = {} }) => {
+  const {
+    authUser = '-',
+    contentLength = '-',
+    date,
+    host = '-',
+    httpVersion,
+    ident = '-',
+    method,
+    statusCode = '-',
+    url,
+  } = parseExpressOptions({ request, response }, overrides);
+  return `${host} ${ident} ${authUser} `
+    + `[${formatDate(date, settings.dateFormat)}] "${method} ${url} `
+    + `HTTP/${httpVersion}" ${statusCode} ${contentLength}`;
+};

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,32 +1,66 @@
-const dateFormat = require('dateformat');
-
-const response = require('./index');
-
-test('Adds a default value for everything except \'httpVersion\', \'method\' and \'url\'', () => {
+test('Adds default values for all except \'date\' \'httpVersion\', \'method\' and \'url\'', () => {
+  const DATE = 'DATE';
+  const FORMATTED_DATE = 'FORMATTED_DATE';
   const HTTP_VERSION = 'HTTP_VERSION';
   const METHOD = 'METHOD';
+  const OVERRIDES = 'OVERRIDES';
+  const REQUEST = 'REQUEST';
+  const RESPONSE = 'RESPONSE';
   const URL = 'URL';
-  const expected = `- - - [-] "${METHOD} ${URL} HTTP/${HTTP_VERSION}" - -`;
+  const mockFormatDate = jest.fn();
+  const mockParseExpressOptions = jest.fn();
+  jest.doMock('./format-date', () => mockFormatDate);
+  jest.doMock('./parse-express-options', () => mockParseExpressOptions);
+  mockFormatDate.mockReturnValue(FORMATTED_DATE);
+  mockParseExpressOptions.mockReturnValue({
+    date: DATE,
+    httpVersion: HTTP_VERSION,
+    method: METHOD,
+    url: URL,
+  });
+  const expectedFormatDateOne = DATE;
+  const expectedFormatDateTwo = undefined;
+  const expectedLog = `- - - [${FORMATTED_DATE}] "${METHOD} ${URL} HTTP/${HTTP_VERSION}" - -`;
+  const expectedParseExpressOptionsOne = { request: REQUEST, response: RESPONSE };
+  const expectedParseExpressOptionsTwo = OVERRIDES;
 
-  const actual = response({ httpVersion: HTTP_VERSION, method: METHOD, url: URL });
+  // eslint-disable-next-line global-require
+  const response = require('./index');
+  const actualLog = response({ overrides: OVERRIDES, request: REQUEST, response: RESPONSE });
+  const formatDateCall = mockFormatDate.mock.calls[0];
+  const parseExpressOptionsCall = mockParseExpressOptions.mock.calls[0];
+  const actualFormatDateOne = formatDateCall[0];
+  const actualFormatDateTwo = formatDateCall[1];
+  const actualParseExpressOptionsOne = parseExpressOptionsCall[0];
+  const actualParseExpressOptionsTwo = parseExpressOptionsCall[1];
 
-  expect(actual).toBe(expected);
+  expect(actualLog).toBe(expectedLog);
+  expect(actualFormatDateOne).toBe(expectedFormatDateOne);
+  expect(actualFormatDateTwo).toBe(expectedFormatDateTwo);
+  expect(actualParseExpressOptionsOne).toEqual(expectedParseExpressOptionsOne);
+  expect(actualParseExpressOptionsTwo).toBe(expectedParseExpressOptionsTwo);
 });
 
-test('Adds all values to the serializer properly', () => {
+test('Adds values for all fields and overrides the date format', () => {
   const AUTH_USER = 'AUTH_USER';
   const CONTENT_LENGTH = 'CONTENT_LENGTH';
-  const DATE = new Date('May 6, 1986 19:10:22 GMT+0200');
+  const DATE = 'DATE';
+  const DATE_FORMAT = 'DATE_FORMAT';
+  const FORMATTED_DATE = 'FORMATTED_DATE';
   const HOST = 'HOST';
   const HTTP_VERSION = 'HTTP_VERSION';
   const IDENT = 'IDENT';
   const METHOD = 'METHOD';
+  const REQUEST = 'REQUEST';
+  const RESPONSE = 'RESPONSE';
   const STATUS_CODE = 'STATUS_CODE';
   const URL = 'URL';
-  const expected = `${HOST} ${IDENT} ${AUTH_USER} [${dateFormat(DATE, 'dd/mmm/yyyy:hh:MM:ss o')}] `
-    + `"${METHOD} ${URL} HTTP/${HTTP_VERSION}" ${STATUS_CODE} ${CONTENT_LENGTH}`;
-
-  const actual = response({
+  const mockFormatDate = jest.fn();
+  const mockParseExpressOptions = jest.fn();
+  jest.doMock('./format-date', () => mockFormatDate);
+  jest.doMock('./parse-express-options', () => mockParseExpressOptions);
+  mockFormatDate.mockReturnValue(FORMATTED_DATE);
+  mockParseExpressOptions.mockReturnValue({
     authUser: AUTH_USER,
     contentLength: CONTENT_LENGTH,
     date: DATE,
@@ -37,6 +71,24 @@ test('Adds all values to the serializer properly', () => {
     statusCode: STATUS_CODE,
     url: URL,
   });
+  const expectedFormatDateOne = DATE;
+  const expectedFormatDateTwo = DATE_FORMAT;
+  const expectedLog = `${HOST} ${IDENT} ${AUTH_USER} [${FORMATTED_DATE}] `
+    + `"${METHOD} ${URL} HTTP/${HTTP_VERSION}" ${STATUS_CODE} ${CONTENT_LENGTH}`;
 
-  expect(actual).toBe(expected);
+  jest.resetModules();
+  // eslint-disable-next-line global-require
+  const response = require('./index');
+  const actualLog = response({
+    request: REQUEST,
+    response: RESPONSE,
+    settings: { dateFormat: DATE_FORMAT },
+  });
+  const formatDateCall = mockFormatDate.mock.calls[0];
+  const actualFormatDateOne = formatDateCall[0];
+  const actualFormatDateTwo = formatDateCall[1];
+
+  expect(actualLog).toBe(expectedLog);
+  expect(actualFormatDateOne).toBe(expectedFormatDateOne);
+  expect(actualFormatDateTwo).toBe(expectedFormatDateTwo);
 });

--- a/src/parse-express-options.js
+++ b/src/parse-express-options.js
@@ -1,0 +1,10 @@
+module.exports = ({ request, response }, overrides = {}) => ({
+  contentLength: response.get('Content-Length'),
+  date: new Date(),
+  host: request.headers.host,
+  httpVersion: request.httpVersion,
+  method: request.method,
+  statusCode: response.statusCode,
+  url: request.originalUrl,
+  ...overrides,
+});

--- a/src/parse-express-options.test.js
+++ b/src/parse-express-options.test.js
@@ -1,0 +1,63 @@
+const parseExpressOptions = require('./parse-express-options');
+
+const Date = jest.fn();
+const get = jest.fn();
+const CONTENT_LENGTH = 'CONTENT_LENGTH';
+const DATE = 'DATE';
+const HOST = 'HOST';
+const HTTP_VERSION = 'HTTP_VERSION';
+const METHOD = 'METHOD';
+const ORIGINAL_URL = 'ORIGINAL_URL';
+const STATUS_CODE = 'STATUS_CODE';
+const request = {
+  headers: { host: HOST },
+  httpVersion: HTTP_VERSION,
+  method: METHOD,
+  originalUrl: ORIGINAL_URL,
+};
+const response = { get, statusCode: STATUS_CODE };
+
+beforeAll(() => {
+  Date.mockImplementation(() => ({ date: DATE }));
+  get.mockReturnValue(CONTENT_LENGTH);
+  global.Date = Date;
+});
+
+test('Parses the given options properly without overrides', () => {
+  const expectedGet = 'Content-Length';
+  const expectedParsed = {
+    contentLength: CONTENT_LENGTH,
+    date: { date: DATE },
+    host: HOST,
+    httpVersion: HTTP_VERSION,
+    method: METHOD,
+    statusCode: STATUS_CODE,
+    url: ORIGINAL_URL,
+  };
+
+  const actualParsed = parseExpressOptions({ request, response });
+  const actualGet = get.mock.calls[0][0];
+
+  expect(actualGet).toEqual(expectedGet);
+  expect(actualParsed).toEqual(expectedParsed);
+});
+
+test('Parses the given options properly with overrides', () => {
+  const CONTENT_LENGTH_OVERRIDE = 'CONTENT_LENGTH_OVERRIDE';
+  const IDENT_OVERRIDE = 'IDENT_OVERRIDE';
+  const overrides = { contentLength: CONTENT_LENGTH_OVERRIDE, ident: IDENT_OVERRIDE };
+  const expected = {
+    contentLength: CONTENT_LENGTH_OVERRIDE,
+    date: { date: DATE },
+    host: HOST,
+    httpVersion: HTTP_VERSION,
+    ident: IDENT_OVERRIDE,
+    method: METHOD,
+    statusCode: STATUS_CODE,
+    url: ORIGINAL_URL,
+  };
+
+  const actual = parseExpressOptions({ request, response }, overrides);
+
+  expect(actual).toEqual(expected);
+});


### PR DESCRIPTION
serializer input now accepts express `request` and `response` objects
all options can now be overridden
date formatting can be changed through settings

BREAKING CHANGE: the format that the serializer accepts has completely changed
take a look at the `README.md` file for more information on the new format